### PR TITLE
fix: content api for frontend events from backend, ui updates and reset command

### DIFF
--- a/src/main/framework/commands.ts
+++ b/src/main/framework/commands.ts
@@ -5,13 +5,14 @@ import short from 'short-uuid'
 import { runInNewContext } from 'node:vm'
 import * as tryRequire from 'try-require'
 import { compile } from '../vendor/webpack'
-import { ExecuteContext } from './runtime'
 import { Settings } from './settings'
+import { ExecuteContext } from './execute-context'
 
+export type FrontendHook = () => Promise<void> | void
 export class Commands {
   public lib: object = {}
   public state: Map<string, object> = new Map<string, object>()
-
+  public handlers: Map<string, FrontendHook> = new Map<string, FrontendHook>()
   constructor(
     private workingDirectory: string,
     private templateDirectory: string

--- a/src/main/framework/execute-context.ts
+++ b/src/main/framework/execute-context.ts
@@ -1,0 +1,95 @@
+import { Workspace } from './workspace'
+import { Command, ResultStream, ResultStreamEvent, Runtime, RuntimeHTMLHandle } from './runtime'
+import { WebContents } from 'electron'
+import createDOMPurify from 'dompurify'
+import { JSDOM } from 'jsdom'
+import Convert from 'ansi-to-html'
+import { readFile } from 'fs-extra'
+
+const convert = new Convert()
+const DOMPurify = createDOMPurify(new JSDOM('').window)
+
+export class ExecuteContext {
+  public start: number = Date.now()
+  constructor(
+    public readonly platform: string,
+    public readonly sender: WebContents,
+    public readonly workspace: Workspace,
+    public readonly runtime: Runtime,
+    public readonly command: Command,
+    public readonly profile: string,
+    public readonly history: {
+      enabled: boolean
+      results: boolean
+      max: number
+    }
+  ) {}
+
+  out(text: string, error: boolean = false): void {
+    const isFinished = this.command.aborted || this.command.complete
+    if (isFinished) {
+      if (!this.command.result.edit) {
+        return
+      }
+    }
+    const raw = text.toString()
+
+    text = DOMPurify.sanitize(raw)
+    text = convert.toHtml(text)
+
+    const streamEntry: ResultStream = {
+      text,
+      error,
+      raw
+    }
+
+    this.command.result.stream.push(streamEntry)
+
+    const streamEvent: ResultStreamEvent = {
+      entry: streamEntry,
+      runtime: this.runtime.id,
+      command: this.command.id
+    }
+
+    if (!this.sender.isDestroyed()) {
+      this.sender.send('runtime.commandEvent', streamEvent)
+    }
+  }
+
+  ui(html: string): RuntimeHTMLHandle {
+    this.out(html, false)
+    return {
+      update(newHTML: string): void {
+        console.log('NEW HTML', newHTML)
+      }
+    }
+  }
+
+  async edit(path: string, callback: (text: string) => void): Promise<void> {
+    const file = await readFile(path)
+
+    this.command.result.edit = {
+      path,
+      modified: false,
+      content: file.toString(),
+      callback
+    }
+
+    this.sender.send('runtime.commandEvent')
+  }
+
+  finish(code: number): void {
+    console.log(this.command)
+    if (this.command.aborted || this.command.complete) {
+      return
+    }
+
+    this.command.result.code = code
+    this.command.complete = true
+    this.command.error = this.command.result.code !== 0
+
+    if (this.history.enabled) {
+      this.workspace.history.append(this.command, this.start, this.profile, this.history.results)
+    }
+  }
+}

--- a/src/main/framework/execute-context.ts
+++ b/src/main/framework/execute-context.ts
@@ -67,6 +67,8 @@ export class ExecuteContext {
     const runtimeId = this.runtime.id
     const commandId = this.command.id
 
+    const command = this.command
+
     const id = short.generate()
     const events = this.events
     const container = (html: string): string => `<span id="${id}">${html}</span>`
@@ -77,7 +79,7 @@ export class ExecuteContext {
     return {
       id,
       update(newHTML: string): void {
-        if (R !== null) {
+        if (R !== null && !command.aborted && !command.complete) {
           R.setText(container(newHTML))
 
           sender.send('runtime.commandEvent')
@@ -111,6 +113,9 @@ export class ExecuteContext {
 
   async fireEvent(eventName: string, handlerId: string): Promise<void> {
     const event = this.eventHandlers.get(handlerId)
+    if (this.command.aborted || this.command.complete) {
+      return
+    }
     if (!event) {
       return
     }

--- a/src/main/framework/execute-context.ts
+++ b/src/main/framework/execute-context.ts
@@ -139,7 +139,6 @@ export class ExecuteContext {
   }
 
   finish(code: number): void {
-    console.log(this.command)
     if (this.command.aborted || this.command.complete) {
       return
     }

--- a/src/main/framework/execute-context.ts
+++ b/src/main/framework/execute-context.ts
@@ -61,7 +61,6 @@ export class ExecuteContext {
 
           sender.send('runtime.commandEvent')
         }
-        console.log('NEW HTML', newHTML)
       }
     }
   }

--- a/src/main/framework/execute-context.ts
+++ b/src/main/framework/execute-context.ts
@@ -64,6 +64,7 @@ export class ExecuteContext {
 
   content(html: string): RuntimeContentHandle {
     const contextId = this.id
+    const runtimeId = this.runtime.id
     const commandId = this.command.id
 
     const id = short.generate()
@@ -91,6 +92,7 @@ export class ExecuteContext {
           event,
           commandId,
           contextId,
+          runtimeId,
           contentId: id,
           handlerId: eventHandlerId
         })
@@ -105,6 +107,17 @@ export class ExecuteContext {
         sender.send('runtime.commandEvent')
       }
     }
+  }
+
+  async fireEvent(eventName: string, handlerId: string): Promise<void> {
+    const event = this.eventHandlers.get(handlerId)
+    if (!event) {
+      return
+    }
+
+    await event({
+      event: eventName
+    })
   }
 
   async edit(path: string, callback: (text: string) => void): Promise<void> {

--- a/src/main/framework/result-stream.ts
+++ b/src/main/framework/result-stream.ts
@@ -6,6 +6,7 @@ export class ResultStream {
     public raw: string,
     public error: boolean = false
   ) {
+    this.raw = this.raw.toString()
     this.text = sanitizeOutput(raw)
   }
 

--- a/src/main/framework/result-stream.ts
+++ b/src/main/framework/result-stream.ts
@@ -1,0 +1,17 @@
+import { sanitizeOutput } from '../util'
+
+export class ResultStream {
+  public text: string
+  constructor(
+    public raw: string,
+    public error: boolean = false
+  ) {
+    this.text = sanitizeOutput(raw)
+  }
+
+  setText(raw: string, error: boolean = this.error): void {
+    this.raw = raw
+    this.text = sanitizeOutput(raw)
+    this.error = error
+  }
+}

--- a/src/main/framework/runtime-events.ts
+++ b/src/main/framework/runtime-events.ts
@@ -115,6 +115,24 @@ export function attach({ app, workspace }: BootstrapContext): void {
   )
 
   ipcMain.handle(
+    'runtime.run-context-event',
+    async (_, event: ResultContentEvent): Promise<boolean> => {
+      const runtime = workspace.runtimes.find((r) => r.id === event.runtimeId)
+      if (!runtime) {
+        return false
+      }
+      const command = runtime.history.find((c) => c.id === event.commandId)
+      if (!command) {
+        return false
+      }
+
+      await command?.context?.fireEvent(event.event, event.handlerId)
+
+      return true
+    }
+  )
+
+  ipcMain.handle(
     'runtime.save-edit',
     async (_, runtimeId: string, commandId: string): Promise<boolean> => {
       const runtime = workspace.runtimes.find((r) => r.id === runtimeId)

--- a/src/main/framework/runtime-executor.ts
+++ b/src/main/framework/runtime-executor.ts
@@ -1,4 +1,3 @@
-import { ExecuteContext } from './runtime'
 import { spawn } from 'node:child_process'
 
 import Reload from './system-commands/reload'
@@ -13,29 +12,27 @@ import Vault from './system-commands/vault'
 import Workspace from './system-commands/workspace'
 import Settings from './system-commands/settings'
 import Edit from './system-commands/edit'
+import Reset from './system-commands/reset'
+import { ExecuteContext } from './execute-context'
 
 const systemCommands: Array<{
   command: string
   alias?: string[]
   task: (context: ExecuteContext, ...args: string[]) => Promise<void> | void
-}> = [Reload, Exit, History, Cd, Tab, Test, Clear, Version, Vault, Workspace, Settings, Edit]
+}> = [Reload, Exit, History, Cd, Tab, Test, Clear, Version, Vault, Workspace, Settings, Edit, Reset]
 export async function execute(context: ExecuteContext): Promise<void | boolean> {
-  const { platform, workspace, runtime, command, out, finish } = context
-  const [cmd, ...args] = command.prompt.split(' ')
+  const [cmd, ...args] = context.command.prompt.split(' ')
 
   // check for system commands
   for (const systemCommand of systemCommands) {
     if (systemCommand.command === cmd || systemCommand?.alias?.includes(cmd)) {
-      await systemCommand.task(context, ...args)
-
-      finish(0)
-      return
+      return systemCommand.task(context, ...args)
     }
   }
 
   // check for user commands
-  if (workspace.commands.has(cmd)) {
-    let result = await Promise.resolve(workspace.commands.run(context, cmd, ...args))
+  if (context.workspace.commands.has(cmd)) {
+    let result = await Promise.resolve(context.workspace.commands.run(context, cmd, ...args))
 
     if (!result) {
       // nothing was replied with, assume this is a run that will happen in time
@@ -46,28 +43,28 @@ export async function execute(context: ExecuteContext): Promise<void | boolean> 
       result = JSON.stringify(result, null, 2)
     }
 
-    out(`${result}`)
+    context.out(`${result}`)
     return
   }
 
   // finally send to the system
-  const [platformProgram, ...platformProgramArgs] = platform.split(' ')
+  const [platformProgram, ...platformProgramArgs] = context.platform.split(' ')
 
   const argsClean = platformProgramArgs.map(
-    (arg: string) => `${arg.replace('$ARGS', command.prompt)}`
+    (arg: string) => `${arg.replace('$ARGS', context.command.prompt)}`
   )
 
   const childSpawn = spawn(platformProgram, argsClean, {
-    cwd: runtime.folder,
+    cwd: context.runtime.folder,
     env: process.env
   })
 
-  childSpawn.stdout.on('data', (data) => out(data))
-  childSpawn.stderr.on('data', (data) => out(data, true))
+  childSpawn.stdout.on('data', (data) => context.out(data))
+  childSpawn.stderr.on('data', (data) => context.out(data, true))
 
   return new Promise((resolve) => {
     childSpawn.on('exit', (code) => {
-      finish(code || 0)
+      context.finish(code || 0)
 
       resolve()
     })

--- a/src/main/framework/runtime.ts
+++ b/src/main/framework/runtime.ts
@@ -13,6 +13,7 @@ export interface Result {
 export interface ResultContentEvent {
   event: string
 
+  runtimeId: string
   commandId: string
   contextId: string
   contentId: string

--- a/src/main/framework/runtime.ts
+++ b/src/main/framework/runtime.ts
@@ -1,4 +1,4 @@
-import { resolveFolderPathForMTERM, Workspace } from './workspace'
+import { resolveFolderPathForMTERM } from './workspace'
 import short from 'short-uuid'
 import { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { resolve } from 'path'
@@ -110,12 +110,6 @@ export class Runtime {
   }
 }
 
-export interface ExecuteContext {
-  platform: string
-  workspace: Workspace
-  runtime: Runtime
-  command: Command
-  edit: (path: string, callback: (content: string) => void) => Promise<void>
-  out: (text: string, error?: boolean) => void
-  finish: (code: number) => void
+export interface RuntimeHTMLHandle {
+  update(html: string): void
 }

--- a/src/main/framework/runtime.ts
+++ b/src/main/framework/runtime.ts
@@ -3,17 +3,26 @@ import short from 'short-uuid'
 import { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { resolve } from 'path'
 import { ResultStream } from './result-stream'
+import { ExecuteContext } from './execute-context'
 
 export interface Result {
   code: number
   stream: ResultStream[]
   edit?: EditFile
 }
+export interface ResultContentEvent {
+  event: string
 
+  commandId: string
+  contextId: string
+  contentId: string
+  handlerId: string
+}
 export interface ResultViewModel {
   code: number
   stream: ResultStream[]
   edit?: EditFileViewModel
+  events: ResultContentEvent[]
 }
 
 export interface ResultStreamEvent {
@@ -40,6 +49,7 @@ export interface Command {
   error: boolean
   id: string
   process?: ChildProcessWithoutNullStreams
+  context?: ExecuteContext
 }
 
 export interface CommandViewModel {

--- a/src/main/framework/runtime.ts
+++ b/src/main/framework/runtime.ts
@@ -2,12 +2,7 @@ import { resolveFolderPathForMTERM } from './workspace'
 import short from 'short-uuid'
 import { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { resolve } from 'path'
-
-export interface ResultStream {
-  error: boolean
-  text: string
-  raw: string
-}
+import { ResultStream } from './result-stream'
 
 export interface Result {
   code: number
@@ -108,8 +103,4 @@ export class Runtime {
 
     return location
   }
-}
-
-export interface RuntimeHTMLHandle {
-  update(html: string): void
 }

--- a/src/main/framework/system-commands/cd.ts
+++ b/src/main/framework/system-commands/cd.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { pathExists, stat } from 'fs-extra'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: 'cd',

--- a/src/main/framework/system-commands/clear.ts
+++ b/src/main/framework/system-commands/clear.ts
@@ -1,4 +1,4 @@
-import { ExecuteContext } from '../runtime'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: 'clear',

--- a/src/main/framework/system-commands/edit.ts
+++ b/src/main/framework/system-commands/edit.ts
@@ -1,7 +1,7 @@
-import { ExecuteContext } from '../runtime'
 import { pathExists, stat } from 'fs-extra'
+import { ExecuteContext } from '../execute-context'
 
-async function exit(context: ExecuteContext): Promise<void> {
+async function edit(context: ExecuteContext): Promise<void> {
   const [, ...args] = context.command.prompt.split(' ')
   const path: string = context.runtime.resolve(args[0] || '.')
 
@@ -27,5 +27,5 @@ async function exit(context: ExecuteContext): Promise<void> {
 export default {
   command: ':edit',
   alias: ['edit'],
-  task: exit
+  task: edit
 }

--- a/src/main/framework/system-commands/exit.ts
+++ b/src/main/framework/system-commands/exit.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { app } from 'electron'
+import { ExecuteContext } from '../execute-context'
 
 async function exit(context: ExecuteContext): Promise<void> {
   if (!context.workspace.removeRuntime(context.runtime)) {

--- a/src/main/framework/system-commands/history.ts
+++ b/src/main/framework/system-commands/history.ts
@@ -1,4 +1,4 @@
-import { ExecuteContext } from '../runtime'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: ':history',

--- a/src/main/framework/system-commands/reload.ts
+++ b/src/main/framework/system-commands/reload.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { RunnerWindow } from '../../window/windows/runner'
+import { ExecuteContext } from '../execute-context'
 
 async function reload(context: ExecuteContext): Promise<void> {
   await context.workspace.load()

--- a/src/main/framework/system-commands/reset.ts
+++ b/src/main/framework/system-commands/reset.ts
@@ -1,0 +1,23 @@
+import { ExecuteContext } from '../execute-context'
+
+async function reset(context: ExecuteContext): Promise<boolean> {
+  context.out('Oh lawd')
+
+  const okay = context.ui(`
+    <h1>Hello</h1>
+  `)
+
+  setTimeout(() => {
+    okay.update(`
+      <h1>Goodbye</h1>
+    `)
+  })
+
+  return false
+}
+
+export default {
+  command: ':reset',
+  alias: ['reset'],
+  task: reset
+}

--- a/src/main/framework/system-commands/reset.ts
+++ b/src/main/framework/system-commands/reset.ts
@@ -1,17 +1,23 @@
 import { ExecuteContext } from '../execute-context'
 
 async function reset(context: ExecuteContext): Promise<boolean> {
-  context.out('Oh lawd')
+  context.out('Time: ')
 
-  const okay = context.content(`
-    <h1>Hello</h1>
-  `)
+  let minute = 0
+  let second = 0
 
-  setTimeout(() => {
-    okay.update(`
-      <h1>Goodbye</h1>
-    `)
-  }, 5000)
+  const M = context.content(`<span>00</span>`)
+
+  context.out(':')
+
+  const S = context.content(`<span>00</span>`)
+
+  setInterval(() => {
+    S.update(`<span>${`${second++}`.padStart(2, '0')}</span>`)
+  }, 1000)
+  setInterval(() => {
+    M.update(`<span>${`${minute++}`.padStart(2, '0')}</span>`)
+  }, 1000 * 60)
 
   return false
 }

--- a/src/main/framework/system-commands/reset.ts
+++ b/src/main/framework/system-commands/reset.ts
@@ -19,6 +19,10 @@ async function reset(context: ExecuteContext): Promise<boolean> {
     M.update(`<span>${`${minute++}`.padStart(2, '0')}</span>`)
   }, 1000 * 60)
 
+  M.on('click', () => {
+    second = 0
+  })
+
   return false
 }
 

--- a/src/main/framework/system-commands/reset.ts
+++ b/src/main/framework/system-commands/reset.ts
@@ -3,7 +3,7 @@ import { ExecuteContext } from '../execute-context'
 async function reset(context: ExecuteContext): Promise<boolean> {
   context.out('Oh lawd')
 
-  const okay = context.ui(`
+  const okay = context.content(`
     <h1>Hello</h1>
   `)
 
@@ -11,7 +11,7 @@ async function reset(context: ExecuteContext): Promise<boolean> {
     okay.update(`
       <h1>Goodbye</h1>
     `)
-  })
+  }, 5000)
 
   return false
 }

--- a/src/main/framework/system-commands/settings.ts
+++ b/src/main/framework/system-commands/settings.ts
@@ -1,7 +1,7 @@
-import { ExecuteContext } from '../runtime'
 import { RunnerWindow } from '../../window/windows/runner'
 import { shell } from 'electron'
 import { parseInt } from 'lodash'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: ':settings',

--- a/src/main/framework/system-commands/tab.ts
+++ b/src/main/framework/system-commands/tab.ts
@@ -1,4 +1,4 @@
-import { ExecuteContext } from '../runtime'
+import { ExecuteContext } from '../execute-context'
 
 async function tab(context: ExecuteContext): Promise<void> {
   context.workspace.addRuntime()

--- a/src/main/framework/system-commands/test.ts
+++ b/src/main/framework/system-commands/test.ts
@@ -1,4 +1,5 @@
-import { ExecuteContext } from '../runtime'
+import { ExecuteContext } from '../execute-context'
+
 export default {
   command: ':test',
   async task(context: ExecuteContext): Promise<void> {

--- a/src/main/framework/system-commands/vault.ts
+++ b/src/main/framework/system-commands/vault.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { PlatformWindow } from '../../window/windows/platform'
+import { ExecuteContext } from '../execute-context'
 
 async function vault(context: ExecuteContext): Promise<void> {
   await context.workspace.showAndHideOthers(PlatformWindow, 'store')

--- a/src/main/framework/system-commands/version.ts
+++ b/src/main/framework/system-commands/version.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { app } from 'electron'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: ':version',

--- a/src/main/framework/system-commands/workspace.ts
+++ b/src/main/framework/system-commands/workspace.ts
@@ -1,5 +1,5 @@
-import { ExecuteContext } from '../runtime'
 import { shell } from 'electron'
+import { ExecuteContext } from '../execute-context'
 
 export default {
   command: ':workspace',

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,7 +1,12 @@
 import { toNumber } from 'lodash'
 import { RunnerBounds } from './model'
 import { BrowserWindow, Display, screen } from 'electron'
+import createDOMPurify from 'dompurify'
+import { JSDOM } from 'jsdom'
+import Convert from 'ansi-to-html'
 
+const convert = new Convert()
+const DOMPurify = createDOMPurify(new JSDOM('').window)
 export function getBoundaryValue(
   value: string | number,
   containerLength: number,
@@ -69,4 +74,11 @@ export function setWindowValueFromPath(window: BrowserWindow, prop: string, valu
       console.error('No handler for = ', prop)
       break
   }
+}
+
+export function sanitizeOutput(text: string | Buffer): string {
+  text = DOMPurify.sanitize(text.toString())
+  text = convert.toHtml(text)
+
+  return text
 }

--- a/src/renderer/src/runner/runner.tsx
+++ b/src/renderer/src/runner/runner.tsx
@@ -201,38 +201,40 @@ export default function Runner(): ReactElement {
     }
   }
 
-  // useEffect(() => {
-  //   inputRef.current?.focus()
-  //
-  //   if (Object.values(pendingTitles).filter((title) => title !== null).length > 0) {
-  //     //editing session in progress
-  //     return
-  //   }
-  //
-  //   // Conditionally handle keydown of letter or arrow to refocus input
-  //   const handleGlobalKeyDown = (event): void => {
-  //     // if pending a title? ignore this key event: user is probably editing the window title
-  //     // and does not care for input
-  //
-  //     if (
-  //       /^[a-zA-Z]$/.test(event.key) ||
-  //       event.key === 'ArrowUp' ||
-  //       event.key === 'ArrowDown' ||
-  //       (!event.shiftKey && !event.ctrlKey && !event.altKey)
-  //     ) {
-  //       if (document.activeElement !== inputRef.current) {
-  //         inputRef.current?.focus()
-  //       }
-  //       handleKeyDown(event)
-  //     }
-  //   }
-  //
-  //   document.addEventListener('keydown', handleGlobalKeyDown)
-  //
-  //   return () => {
-  //     document.removeEventListener('keydown', handleGlobalKeyDown)
-  //   }
-  // }, [])
+  useEffect(() => {
+    const checkAndSendEventForContent = (event): void => {
+      const element = event.target
+
+      const runtime = runtimeList.find((r) => r.target)
+      if (!runtime) {
+        return
+      }
+      const eventList =
+        historyIndex === -1 ? runtime.result.events : runtime.history[historyIndex].result.events
+
+      const matchingEvents = eventList.filter(
+        (backendEvent) =>
+          [element.parentElement.id, element.id].includes(backendEvent.contentId) &&
+          event.type === backendEvent.event
+      )
+
+      matchingEvents.forEach((eventToFire) => {
+        window.electron.ipcRenderer.invoke('runtime.run-context-event', eventToFire).then(() => {
+          return reloadRuntimesFromBackend()
+        })
+      })
+    }
+
+    const clickEvent = (event): void => {
+      checkAndSendEventForContent(event)
+    }
+
+    document.addEventListener('click', clickEvent)
+
+    return () => {
+      document.removeEventListener('click', clickEvent)
+    }
+  }, [historyIndex, runtimeList])
 
   useEffect(() => {
     reloadRuntimesFromBackend().catch((error) => console.error(error))

--- a/src/renderer/src/runner/runner.tsx
+++ b/src/renderer/src/runner/runner.tsx
@@ -207,7 +207,9 @@ export default function Runner(): ReactElement {
       return
     }
     const eventList =
-      historyIndex === -1 ? runtime.result.events : runtime.history[historyIndex].result.events
+      (historyIndex === -1
+        ? runtime.result.events
+        : runtime.history[historyIndex]?.result?.events) || []
 
     const eventMap = eventList.map((o) => o.event)
     const eventMapSet = new Set<string>()

--- a/src/renderer/src/runner/runner.tsx
+++ b/src/renderer/src/runner/runner.tsx
@@ -202,15 +202,22 @@ export default function Runner(): ReactElement {
   }
 
   useEffect(() => {
+    const runtime = runtimeList.find((r) => r.target)
+    if (!runtime) {
+      return
+    }
+    const eventList =
+      historyIndex === -1 ? runtime.result.events : runtime.history[historyIndex].result.events
+
+    const eventMap = eventList.map((o) => o.event)
+    const eventMapSet = new Set<string>()
+
+    for (const event of eventMap) {
+      eventMapSet.add(event)
+    }
+
     const checkAndSendEventForContent = (event): void => {
       const element = event.target
-
-      const runtime = runtimeList.find((r) => r.target)
-      if (!runtime) {
-        return
-      }
-      const eventList =
-        historyIndex === -1 ? runtime.result.events : runtime.history[historyIndex].result.events
 
       const matchingEvents = eventList.filter(
         (backendEvent) =>
@@ -225,14 +232,16 @@ export default function Runner(): ReactElement {
       })
     }
 
-    const clickEvent = (event): void => {
-      checkAndSendEventForContent(event)
-    }
+    const eventListName = Array.from(eventMapSet.values())
 
-    document.addEventListener('click', clickEvent)
+    eventListName.forEach((eventName) =>
+      document.addEventListener(eventName, checkAndSendEventForContent)
+    )
 
     return () => {
-      document.removeEventListener('click', clickEvent)
+      eventListName.forEach((eventName) =>
+        document.removeEventListener(eventName, checkAndSendEventForContent)
+      )
     }
   }, [historyIndex, runtimeList])
 

--- a/src/renderer/src/runner/runtime.ts
+++ b/src/renderer/src/runner/runtime.ts
@@ -14,6 +14,7 @@ export interface Result {
 export interface ResultContentEvent {
   event: string
 
+  runtimeId: string
   commandId: string
   contextId: string
   contentId: string

--- a/src/renderer/src/runner/runtime.ts
+++ b/src/renderer/src/runner/runtime.ts
@@ -7,9 +7,18 @@ export interface ResultStream {
 export interface Result {
   code: number
   stream: ResultStream[]
+  events: ResultContentEvent[]
   edit?: EditFile
 }
 
+export interface ResultContentEvent {
+  event: string
+
+  commandId: string
+  contextId: string
+  contentId: string
+  handlerId: string
+}
 export interface ResultStreamEvent {
   runtime: string
   command: string


### PR DESCRIPTION
resolves #14 

introduces the `context.content(`<button>Yes</button>`)` operation

content can have events attached to them e.g

````typescript
  const no = context.content(`<button>No</button>`)
  
  no.on('click', () => {
    context.out('\n\nDeclined reset')
    context.finish(0)
  })
````

or more complex -
```typescript
  context.out('Reset all mterm settings, commands, modules?\n')

  const yes = context.content(`<button>Yes</button>`)

  context.out('|')

  const no = context.content(`<button>No</button>`)

  no.on('click', () => {
    context.out('\n\nDeclined reset')
    context.finish(0)
  })

  yes.on('click', async () => {
    context.out('\n\nCleaning...')

    await remove(context.workspace.folder)

    context.out('\nReloading...')

    await context.workspace.load()
    context.out('- settings reloaded \n')

    await context.workspace.commands.load(context.workspace.settings)
    context.out('- commands reloaded \n')

    await context.workspace.reload(RunnerWindow)
    context.out('- window reloaded \n')

    context.finish(0)
  })
```

![image](https://github.com/mterm-io/mterm/assets/7341502/133e9224-0490-4045-b861-dedc74b40c65)


content can also be updated e.g (a clock)

````typescript
  context.out('Time: ')

  let minute = 0
  let second = 0

  const M = context.content(`<span>00</span>`)

  context.out(':')

  const S = context.content(`<span>00</span>`)

  setInterval(() => {
    S.update(`<span>${`${second++}`.padStart(2, '0')}</span>`)
  }, 1000)
  setInterval(() => {
    M.update(`<span>${`${minute++}`.padStart(2, '0')}</span>`)
  }, 1000 * 60)
````

![image](https://github.com/mterm-io/mterm/assets/7341502/c2ef8a46-b4f1-4d29-968b-2c43546058ae)


